### PR TITLE
Alterando Parser para lidar com string ao invés de ifstream

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -1,20 +1,21 @@
 #ifndef PARSER_H
-#include "linked_stack.h"
-#include <stdio.h>
+#define PARSER_H
+
 #include <string.h>
-#include <fstream>
+
+#include "linked_stack.h"
 
 class Parser {
-  public:
-    Parser(std::ifstream &file);
-    //! Verify semantics
-    bool parse_file();
-    //! Checks if a opening_tag matches a closing_tag
-    bool match(std::string opening_tag, std::string closing_tag);
+ public:
+  Parser(std::string content);
+  //! Verify semantics
+  bool parse_file();
+  //! Checks if a opening_tag matches a closing_tag
+  bool match(std::string opening_tag, std::string closing_tag);
 
-  private:
-      std::ifstream &file_;
-      structures::LinkedStack<std::string> linked_stack;
+ private:
+  std::string content_;
+  structures::LinkedStack<std::string> linked_stack;
 };
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -14,6 +14,9 @@ class Parser {
   bool match(std::string opening_tag, std::string closing_tag);
 
  private:
+  //! Check if content_at_index is equal to tag_element
+  bool isTagElement(const char& content_at_index, const char& tag_element);
+
   std::string content_;
   structures::LinkedStack<std::string> linked_stack;
 };

--- a/include/parser.h
+++ b/include/parser.h
@@ -12,10 +12,11 @@ class Parser {
   bool parse_file();
   //! Checks if a opening_tag matches a closing_tag
   bool match(std::string opening_tag, std::string closing_tag);
-
  private:
   //! Check if content_at_index is equal to tag_element
   bool isTagElement(const char& content_at_index, const char& tag_element);
+
+  std::string assembly_tag(std::size_t begin, std::size_t index);
 
   std::string content_;
   structures::LinkedStack<std::string> linked_stack;

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <fstream>
+#include <sstream>
 #include "include/parser.h"
 #include <stdexcept>
 
@@ -17,7 +18,11 @@ int main (int argc, char *argv[]) {
     exit(1);
   }
 
-  Parser parser(file);
+  stringstream buffer;
+  buffer << file.rdbuf();
+  file.close();
+
+  Parser parser(buffer.str());
 
   bool valid = parser.parse_file();
 

--- a/src/linked_stack.cpp
+++ b/src/linked_stack.cpp
@@ -1,6 +1,6 @@
 #include "linked_stack.h"
 
-template<typename T>
+template <typename T>
 structures::LinkedStack<T>::LinkedStack(void) {
   top_ = nullptr;
   size_ = 0u;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <parser.h>
 #include <string.h>
 #include <stdio.h>
@@ -37,17 +38,16 @@ bool Parser::parse_file() {
     }
   }
 
-  if (!linked_stack.empty()) {
-    return false;
-  }
-
-  return true;
+  return linked_stack.empty();
 }
 
 bool Parser::match(std::string opening_tag, std::string closing_tag) {
   std::regex reg ("\\W");
-  bool match = std::regex_replace(opening_tag, reg, "")
-    .compare(std::regex_replace(closing_tag, reg, ""));
+
+  std::string opening_tag_text = std::regex_replace(opening_tag, reg, "");
+  std::string closing_tag_text = std::regex_replace(closing_tag, reg, "");
+
+  bool match = opening_tag_text.compare(closing_tag_text);
 
   return match == 0;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,11 +1,11 @@
 #include <parser.h>
 #include <stdio.h>
-#include <string.h>
 
 #include <fstream>
 #include <iostream>
 #include <regex>
 #include <stdexcept>
+#include <string>
 
 static const char LEFT_BRACKET = '<';
 static const char RIGHT_BRACKET = '>';
@@ -13,23 +13,23 @@ static const char SLASH = '/';
 
 Parser::Parser(std::string content) : content_(content) {}
 
-
 bool Parser::parse_file() {
   std::string tag;
   std::size_t tag_begin;
   std::size_t tag_length;
 
   auto index = 0u;
+  char content;
+
   while (index < content_.length()) {
-    char content = content_[index];
+    content = content_[index];
 
     if (isTagElement(content, LEFT_BRACKET)) {
       tag_begin = index;
     }
 
     if (isTagElement(content, RIGHT_BRACKET)) {
-      tag_length = index + 1 - tag_begin;
-      tag = content_.substr(tag_begin, tag_length);
+      tag = assembly_tag(tag_begin, index);
 
       if (isTagElement(tag[1], SLASH)) {
         std::string last_tag = linked_stack.pop();
@@ -57,6 +57,13 @@ bool Parser::match(std::string opening_tag, std::string closing_tag) {
   return match == 0;
 }
 
-bool Parser::isTagElement(const char& content_at_index, const char& tag_element) {
+bool Parser::isTagElement(const char& content_at_index,
+                          const char& tag_element) {
   return content_at_index == tag_element;
+}
+
+std::string Parser::assembly_tag(std::size_t begin, std::size_t index) {
+  std::size_t length;
+  length = index + 1 - begin;
+  return content_.substr(begin, length);
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -16,7 +16,6 @@ Parser::Parser(std::string content) : content_(content) {}
 bool Parser::parse_file() {
   std::string tag;
   std::size_t tag_begin;
-  std::size_t tag_length;
 
   auto index = 0u;
   char content;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -13,6 +13,7 @@ static const char SLASH = '/';
 
 Parser::Parser(std::string content) : content_(content) {}
 
+
 bool Parser::parse_file() {
   std::string tag;
   std::size_t tag_begin;
@@ -20,15 +21,17 @@ bool Parser::parse_file() {
 
   auto index = 0u;
   while (index < content_.length()) {
-    if (content_[index] == LEFT_BRACKET) {
+    char content = content_[index];
+
+    if (isTagElement(content, LEFT_BRACKET)) {
       tag_begin = index;
     }
 
-    if (content_[index] == RIGHT_BRACKET) {
+    if (isTagElement(content, RIGHT_BRACKET)) {
       tag_length = index + 1 - tag_begin;
       tag = content_.substr(tag_begin, tag_length);
 
-      if (tag[1] == SLASH) {
+      if (isTagElement(tag[1], SLASH)) {
         std::string last_tag = linked_stack.pop();
         if (!match(tag, last_tag)) {
           return false;
@@ -52,4 +55,8 @@ bool Parser::match(std::string opening_tag, std::string closing_tag) {
   bool match = opening_tag_text.compare(closing_tag_text);
 
   return match == 0;
+}
+
+bool Parser::isTagElement(const char& content_at_index, const char& tag_element) {
+  return content_at_index == tag_element;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,8 +1,9 @@
-#include <iostream>
 #include <parser.h>
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
+
 #include <fstream>
+#include <iostream>
 #include <regex>
 #include <stdexcept>
 
@@ -10,39 +11,40 @@ static const char LEFT_BRACKET = '<';
 static const char RIGHT_BRACKET = '>';
 static const char SLASH = '/';
 
-Parser::Parser(std::ifstream &file) : file_(file) {}
+Parser::Parser(std::string content) : content_(content) {}
 
 bool Parser::parse_file() {
-  std::string line;
   std::string tag;
   std::size_t tag_begin;
   std::size_t tag_length;
-  while (getline(file_, line)) {
-    for (size_t i = 0; i < line.size(); i++) {
-      if(line[i] == LEFT_BRACKET) {
-        tag_begin = i;
-      }
 
-      if (line[i] == RIGHT_BRACKET) {
-        tag_length = i + 1 - tag_begin;
-        tag = line.substr(tag_begin, tag_length);
+  auto index = 0u;
+  while (index < content_.length()) {
+    if (content_[index] == LEFT_BRACKET) {
+      tag_begin = index;
+    }
 
-        if (tag[1] == SLASH) {
-          std::string last_tag = linked_stack.pop();
-          if(!match(last_tag, tag))
-            return false;
-        } else {
-          linked_stack.push(tag);
+    if (content_[index] == RIGHT_BRACKET) {
+      tag_length = index + 1 - tag_begin;
+      tag = content_.substr(tag_begin, tag_length);
+
+      if (tag[1] == SLASH) {
+        std::string last_tag = linked_stack.pop();
+        if (!match(tag, last_tag)) {
+          return false;
         }
+      } else {
+        linked_stack.push(tag);
       }
     }
+    index++;
   }
 
   return linked_stack.empty();
 }
 
 bool Parser::match(std::string opening_tag, std::string closing_tag) {
-  std::regex reg ("\\W");
+  std::regex reg("\\W");
 
   std::string opening_tag_text = std::regex_replace(opening_tag, reg, "");
   std::string closing_tag_text = std::regex_replace(closing_tag, reg, "");

--- a/tests/AllTests.cpp
+++ b/tests/AllTests.cpp
@@ -1,4 +1,8 @@
+#include <stdio.h>
+#include <string.h>
+
 #include <fstream>
+#include <sstream>
 
 #include "gtest/gtest.h"
 #include "linked_stack.h"
@@ -14,19 +18,21 @@ int main(int argc, char* argv[]) {
 
 class ParserTest : public ::testing::Test {
  protected:
-  std::ifstream file1{"assets/dataset01.xml"};
-  std::ifstream file4{"assets/dataset04.xml"};
-  std::ifstream file6{"assets/dataset06.xml"};
-  Parser parser1{file1};
-  Parser parser4{file4};
-  Parser parser6{file6};
+  std::string setup(std::string path) {
+    std::stringstream buffer;
+    std::ifstream file(path);
+    buffer << file.rdbuf();
+    file.close();
 
-  std::ifstream file2{"assets/dataset02.xml"};
-  std::ifstream file3{"assets/dataset03.xml"};
-  std::ifstream file5{"assets/dataset05.xml"};
-  Parser parser2{file2};
-  Parser parser3{file3};
-  Parser parser5{file5};
+    return buffer.str();
+  }
+
+  Parser parser1{setup("assets/dataset01.xml")};
+  Parser parser2{setup("assets/dataset02.xml")};
+  Parser parser3{setup("assets/dataset03.xml")};
+  Parser parser4{setup("assets/dataset04.xml")};
+  Parser parser5{setup("assets/dataset05.xml")};
+  Parser parser6{setup("assets/dataset06.xml")};
 };
 
 TEST_F(ParserTest, ParseFileReturnsTrueWhenValidXML) {

--- a/tests/AllTests.cpp
+++ b/tests/AllTests.cpp
@@ -41,6 +41,15 @@ TEST_F(ParserTest, ParseFileReturnsFalseWhenInvalidXML) {
   ASSERT_FALSE(parser5.parse_file());
 }
 
+TEST_F(ParserTest, MatchReturnsTrueWhenMatches) {
+  ASSERT_TRUE(parser1.match("<oi>", "</oi>"));
+  ASSERT_TRUE(parser1.match("<tchau>", "</tchau>"));
+}
+
+TEST_F(ParserTest, MatchReturnsFalseWhenDontMatch) {
+  ASSERT_FALSE(parser1.match("<oi>", "</io>"));
+}
+
 class LinkedStackTest : public ::testing::Test {
  protected:
   structures::LinkedStack<int> stack{};


### PR DESCRIPTION
### parser.h
* Removi o atributo file_
* Adicionei o atributo content_ (std::string)
* Removi includes desnecessários
* Adicionei uma função privada isTagElement() pra resolver remover duplicação nos ifs de file_parser 

### parser.cpp
* Alterei o construtor pra usar content_
* Alterei o método parse_file() para trabalhar com o atributo content_ ao invés de file_ (ficou com um laço a menos)
* Implementei isTagElement()
* Alterei os ifs do parse_file pra usar isTagElement() 

### main.cpp
* Usando rdbuff para inicializar o parser com uma string ao invés de um arquivo

### AllTests.cpp
* Alterei os testes pra acomodar a mudança em parser
* Testando parse_file() em todos os datasets (e funfando)
* Testando match() (passando)

Dei um make format por isso que o diff ta ridículo, my bad :(